### PR TITLE
Make videoplayer work with expo SDK v34 and remove warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 ## This repo is no longer maintained. Please head on over to https://github.com/ihmpavel/expo-video-player instead!
 
+Made usable on expo SDK v34 by [VivifyIdeas](https://github.com/vivifyideas).

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Audio, Video } from 'expo';
+import { Audio, Video } from 'expo-av';
 import {
   View,
   Dimensions,
@@ -9,6 +9,7 @@ import {
   Text,
   Slider,
   NetInfo,
+  Platform
 } from 'react-native';
 import PropTypes from 'prop-types';
 import reactMixin from 'react-mixin';
@@ -200,6 +201,8 @@ export default class VideoPlayer extends React.Component {
         playsInSilentModeIOS: true,
         shouldDuckAndroid: true,
         interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+        playThroughEarpieceAndroid: Platform.OS === 'ios',
+        staysActiveInBackground: true
       });
     } catch (e) {
       this.props.errorCallback({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/videoplayer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Customizable videoplayer controls for expo",
   "author": "Abi Raja <abimanyuraja@gmail.com>",
   "main": "index.js",
@@ -37,6 +37,6 @@
     "react-docgen-markdown-renderer": "^1.0.1"
   },
   "peerDependencies": {
-    "expo": ">=22.0.0"
+    "expo": ">=34.0.3"
   }
 }


### PR DESCRIPTION
- Use `Audio` and `Video` from `expo-av`,
- Fix warnings for missing params.

Original PR: https://github.com/expo/videoplayer/pull/38